### PR TITLE
Make treeof work with chaperone and impersonator contracts.

### DIFF
--- a/unstable/contract.rkt
+++ b/unstable/contract.rkt
@@ -132,8 +132,14 @@
 ;; Added by ntoronto
 
 (define (treeof elem-contract)
-  (or/c elem-contract
-        (listof (recursive-contract (treeof elem-contract) #:flat))))
+  (define tree-contract
+    (or/c elem-contract
+          (listof
+            (cond
+              [(flat-contract? elem-contract) (recursive-contract tree-contract #:flat)]
+              [(chaperone-contract? elem-contract) (recursive-contract tree-contract #:chaperone)]
+              [else (recursive-contract tree-contract)]))))
+  tree-contract)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;


### PR DESCRIPTION
Closes PR13504.

I didn't see any tests so didn't add any, but tested manually.
